### PR TITLE
Remove LICENSE boilerplate and include attribution in README.md

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -174,28 +174,3 @@
       of your accepting any such warranty or additional liability.
 
    END OF TERMS AND CONDITIONS
-
-   APPENDIX: How to apply the Apache License to your work.
-
-      To apply the Apache License to your work, attach the following
-      boilerplate notice, with the fields enclosed by brackets "[]"
-      replaced with your own identifying information. (Don't include
-      the brackets!)  The text should be enclosed in the appropriate
-      comment syntax for the file format. We also recommend that a
-      file or class name and description of purpose be included on the
-      same "printed page" as the copyright notice for easier
-      identification within third-party archives.
-
-   Copyright [yyyy] [name of copyright owner]
-
-   Licensed under the Apache License, Version 2.0 (the "License");
-   you may not use this file except in compliance with the License.
-   You may obtain a copy of the License at
-
-       http://www.apache.org/licenses/LICENSE-2.0
-
-   Unless required by applicable law or agreed to in writing, software
-   distributed under the License is distributed on an "AS IS" BASIS,
-   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-   See the License for the specific language governing permissions and
-   limitations under the License.

--- a/README.md
+++ b/README.md
@@ -18,10 +18,21 @@ before reaching out for help
 
 ### Please don't
 - Use a code generator to write the client library
+- Use a library for your client (e.g: go-resty). Only test libraries are allowed.
 - Implement an authentication scheme
 
 ## How to submit your exercise
-- Include your name in the README. If you are new to Go, please also mention this in the README so that we can consider this when reviewing your exercise 
+- Include your name in the README. If you are new to Go, please also mention this in the README so that we can consider this when reviewing your exercise
 - Create a private [GitHub](https://help.github.com/en/articles/create-a-repo) repository, copy the `docker-compose` from this repository
 - [Invite](https://help.github.com/en/articles/inviting-collaborators-to-a-personal-repository) @form3tech-interviewer-1 to your private repo
 - Let us know you've completed the exercise using the link provided at the bottom of the email from our recruitment team
+
+## License
+Copyright 2019 Form3 Financial Cloud
+
+Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ before reaching out for help
 - Let us know you've completed the exercise using the link provided at the bottom of the email from our recruitment team
 
 ## License
-Copyright 2019 Form3 Financial Cloud
+Copyright 2019-2020 Form3 Financial Cloud
 
 Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License.
 You may obtain a copy of the License at


### PR DESCRIPTION
The license section in `README.md` has been created to reflect that of
`form3tech-oss/aws-auth-refresher` where the Apache license also is used.