### PR TITLE
Drop unused Makefile

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,1 @@
 .idea
-build/output

--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,0 @@
-.PHONY: docs
-docs:
-	@docker run -v $$PWD/:/docs pandoc/latex -f markdown /docs/README.md -o /docs/build/output/README.pdf


### PR DESCRIPTION
The Makefile target is broken and provides little use.

I think most people can read a Markdown file without first converting it to a PDF.