### PR TITLE
Sort services so that they always start in correct order

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,26 @@
 version: '3'
 
 services:
+  postgresql:
+    image: postgres:9.5-alpine
+    healthcheck:
+      test: [ "CMD", "pg_isready", "-q", "-d", "postgres", "-U", "root" ]
+      timeout: 45s
+      interval: 10s
+      retries: 10
+    restart: always
+    environment:
+      - POSTGRES_USER=root
+      - POSTGRES_PASSWORD=password
+    volumes:
+      - ./scripts/db:/docker-entrypoint-initdb.d/
+
+  vault:
+    image: vault:1.6.3
+    environment:
+      - SKIP_SETCAP=1
+      - VAULT_DEV_ROOT_TOKEN_ID=8fb95528-57c6-422e-9722-d2147bcba8ed
+
   accountapi:
     image: form3tech/interview-accountapi:v1.0.0-50-ga251d4fc
     restart: on-failure
@@ -21,22 +41,3 @@ services:
       - DATABASE-PASSWORD=123
     ports:
       - 8080:8080
-  postgresql:
-    image: postgres:9.5-alpine
-    healthcheck:
-      test: [ "CMD", "pg_isready", "-q", "-d", "postgres", "-U", "root" ]
-      timeout: 45s
-      interval: 10s
-      retries: 10
-    restart: always
-    environment:
-      - POSTGRES_USER=root
-      - POSTGRES_PASSWORD=password
-    volumes:
-      - ./scripts/db:/docker-entrypoint-initdb.d/
-
-  vault:
-    image: vault:1.6.3
-    environment:
-      - SKIP_SETCAP=1
-      - VAULT_DEV_ROOT_TOKEN_ID=8fb95528-57c6-422e-9722-d2147bcba8ed


### PR DESCRIPTION
In older versions of docker-compose running on Linux (1.23), small numbers of containers get scheduled to start up in the order in which they are listed in docker-compose.yml. In this case, it was trying to start up the api first. This container hangs because it cannot open connections to postgres and vault. If we put the api at the bottom of the file it will always start after postgres and vault are up.

Other than adjusting the ordering, no other changes were made.