### PR TITLE
Fix Form3 documentation link

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Engineers at Form3 build highly available distributed systems in a microservices
 ## Instructions
 The goal of this exercise is to write a client library in Go to access our fake account API, which is provided as a Docker
 container in the file `docker-compose.yaml` of this repository. Please refer to the
-[Form3 documentation](http://api-docs.form3.tech/api.html#organisation-accounts) for information on how to interact with the API. Please note that the fake account API does not require any authorisation or authentication.
+[Form3 documentation](https://www.api-docs.form3.tech/api/tutorials/getting-started/create-an-account) for information on how to interact with the API. Please note that the fake account API does not require any authorisation or authentication.
 
 A mapping of account attributes can be found in [models.go](./models.go). Can be used as a starting point, usage of the file is not required.
 


### PR DESCRIPTION
Documentation structure changed and the old link redirects to a different documentation part which may confuse candidates.